### PR TITLE
Use yarn layer as target for SBoM generation

### DIFF
--- a/build.go
+++ b/build.go
@@ -117,7 +117,7 @@ func Build(
 			logger.GeneratingSBOM(yarnLayer.Path)
 			var sbomContent sbom.SBOM
 			duration, err = clock.Measure(func() error {
-				sbomContent, err = sbomGenerator.GenerateFromDependency(dependency, context.WorkingDir)
+				sbomContent, err = sbomGenerator.GenerateFromDependency(dependency, yarnLayer.Path)
 				return err
 			})
 			if err != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -168,7 +168,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			URI:     "yarn-dependency-uri",
 			Version: "yarn-dependency-version",
 		}))
-		Expect(sbomGenerator.GenerateFromDependencyCall.Receives.Dir).To(Equal(workingDir))
+		Expect(sbomGenerator.GenerateFromDependencyCall.Receives.Dir).To(Equal(layer.Path))
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
 		Expect(buffer.String()).To(ContainSubstring("Executing build process"))


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->
`GenerateFromDependency()` should receive the path to the yarn layer instead of `/workspace` just as in other dependency buildpacks ([cpython](https://github.com/paketo-buildpacks/cpython/blob/de3c6d54a0a1288fb181704755fdd233fc60f370/build.go#L119), [node-engine](https://github.com/paketo-buildpacks/node-engine/blob/c15608660039b5093a1e9abc9d626cf47882e459/build.go#L139)).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
