### PR TITLE
Add jammy stack support

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,7 +25,7 @@ api = "0.7"
     sha256 = "2f6ed610be8b877d2abadafde43044280ee73a88e82787853450d9558fb15e70"
     source = "https://github.com/yarnpkg/yarn/releases/download/v1.22.16/yarn-v1.22.16.tar.gz"
     source_sha256 = "c0369d6a9aeb4f3b86095c6e6f64de7a7555a888e03260c3f02727636e1f1693"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/yarn/yarn_1.22.16_linux_noarch_bionic_2f6ed610.tgz"
     version = "1.22.16"
 
@@ -38,7 +38,7 @@ api = "0.7"
     sha256 = "812ad0ae25801885e0422d018d1e79a6ac5903b613621cb424159518631f8bfd"
     source = "https://github.com/yarnpkg/yarn/releases/download/v1.22.17/yarn-v1.22.17.tar.gz"
     source_sha256 = "267982c61119a055ba2b23d9cf90b02d3d16c202c03cb0c3a53b9633eae37249"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/yarn/yarn_1.22.17_linux_noarch_bionic_812ad0ae.tgz"
     version = "1.22.17"
 
@@ -49,3 +49,6 @@ api = "0.7"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

#242 

- Tested this buildpack in conjunction with other yarn-related buildpacks on the Jammy Buildpackless Base builder to successfully build https://github.com/paketo-buildpacks/yarn-start/blob/main/integration/graceful_shutdown_test.go. 

- It looks like [the "compilation" code](https://github.com/cloudfoundry/buildpacks-ci/blob/ff0027d31d6749d67670b83a7b2da500d992c435/tasks/build-binary-new/builder.rb#L801-L815) is only stripping a tar directory level off, but not actually compiling anything. The dependency source is OS agnostic, so it's not surprising that this works on Jammy and Bionic. 

- A [separate PR](https://github.com/paketo-buildpacks/dep-server/pull/192) for adding the Jammy stack to subsequent Yarn versions is also open.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).