### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yarn Cloud Native Buildpack
+# Paketo Buildpack for Yarn
 
 The Yarn CNB provides the [Yarn Package manager](https://yarnpkg.com). The
 buildpack installs `yarn` onto the `$PATH` which makes it available for

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/yarn"
   id = "paketo-buildpacks/yarn"
-  name = "Paketo Yarn Buildpack"
+  name = "Paketo Buildpack for Yarn"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Yarn Buildpack' to 'Paketo Buildpack for Yarn'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
