### PR TITLE
Allow all stacks

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,7 +25,7 @@ api = "0.7"
     checksum = "sha256:77987b1ade01c6fe27ff8d081bb30d97b115bb9962bc2a98765b120dd7ef714d"
     source = "https://github.com/yarnpkg/yarn/releases/download/v1.22.18/yarn-v1.22.18.tar.gz"
     source-checksum = "sha256:816e5c073b3d35936a398d1fe769ebbcd517298e3510b649e8fc67cd3a62e113"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy","io.buildpacks.stacks.ubi8"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy","io.buildpacks.stacks.ubi8", "*"]
     uri = "https://deps.paketo.io/yarn/yarn_1.22.18_linux_noarch_bionic_77987b1a.tgz"
     version = "1.22.18"
 
@@ -38,7 +38,7 @@ api = "0.7"
     checksum = "sha256:3235ba55a7e669476697fe4506df7fe5179a4448b2c22c96039ff6800c9a7daa"
     source = "https://github.com/yarnpkg/yarn/releases/download/v1.22.19/yarn-v1.22.19.tar.gz"
     source-checksum = "sha256:732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy", "io.buildpacks.stacks.ubi8"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy", "io.buildpacks.stacks.ubi8", "*"]
     uri = "https://deps.paketo.io/yarn/yarn_1.22.19_linux_noarch_bionic_3235ba55.tgz"
     version = "1.22.19"
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,7 +25,7 @@ api = "0.7"
     checksum = "sha256:77987b1ade01c6fe27ff8d081bb30d97b115bb9962bc2a98765b120dd7ef714d"
     source = "https://github.com/yarnpkg/yarn/releases/download/v1.22.18/yarn-v1.22.18.tar.gz"
     source-checksum = "sha256:816e5c073b3d35936a398d1fe769ebbcd517298e3510b649e8fc67cd3a62e113"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy","io.buildpacks.stacks.ubi8", "*"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy", "*"]
     uri = "https://deps.paketo.io/yarn/yarn_1.22.18_linux_noarch_bionic_77987b1a.tgz"
     version = "1.22.18"
 
@@ -38,7 +38,7 @@ api = "0.7"
     checksum = "sha256:3235ba55a7e669476697fe4506df7fe5179a4448b2c22c96039ff6800c9a7daa"
     source = "https://github.com/yarnpkg/yarn/releases/download/v1.22.19/yarn-v1.22.19.tar.gz"
     source-checksum = "sha256:732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy", "io.buildpacks.stacks.ubi8", "*"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy", "*"]
     uri = "https://deps.paketo.io/yarn/yarn_1.22.19_linux_noarch_bionic_3235ba55.tgz"
     version = "1.22.19"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This is a mirror of [this pull request for node-engine](https://github.com/paketo-buildpacks/node-engine/pull/795).

When trying to run a [sample](https://github.com/paketo-buildpacks/samples/tree/main/java/java-node/maven-yarn) using the `yarn` buildpack on Amazon Linux 2023, I'm getting the error below.

```
[2024-01-05T16:26:59.194Z] [builder] failed to satisfy "yarn" dependency version constraint "*": no compatible versions on "io.buildpacks.stacks.amazonlinux2023" stack. Supported versions are: []
```

I saw that [ubi8 was recently added](https://github.com/paketo-buildpacks/yarn/pull/406). Instead of adding my AL2023 stack ID, or every unique stack ID, I changed ubi8 to an asterisk.  

You already have the asterisk in the stack ID at the [bottom of the buildpack.toml file](https://github.com/paketo-buildpacks/yarn/blob/main/buildpack.toml#L56-L57). I don't see any reason why there can't be an asterisk in the stack ID in each dependency.

```
[[stacks]]
  id = "*"
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

Allowing using this buildpack on all stacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
