### PR TITLE
Using regex to match uuids and versions on unit tests

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -150,7 +151,15 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(spdx.Extension).To(Equal("spdx.json"))
 		content, err = io.ReadAll(spdx.Content)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(content)).To(MatchJSON(`{
+
+		versionPattern := regexp.MustCompile(`"licenseListVersion": "\d+\.\d+"`)
+		contentReplaced := versionPattern.ReplaceAllString(string(content), `"licenseListVersion": "x.x"`)
+
+		uuidRegex := regexp.MustCompile(`[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}`)
+
+		contentReplaced = uuidRegex.ReplaceAllString(contentReplaced, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+		Expect(string(contentReplaced)).To(MatchJSON(`{
 			"SPDXID": "SPDXRef-DOCUMENT",
 			"creationInfo": {
 				"created": "0001-01-01T00:00:00Z",
@@ -158,10 +167,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"Organization: Anchore, Inc",
 					"Tool: -"
 				],
-				"licenseListVersion": "3.25"
+				"licenseListVersion": "x.x"
 			},
 			"dataLicense": "CC0-1.0",
-			"documentNamespace": "https://paketo.io/unknown-source-type/unknown-9ecf240a-d971-5a3c-8e7b-6d3f3ea4d9c2",
+            "documentNamespace": "https://paketo.io/unknown-source-type/unknown-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 			"name": "unknown",
 			"packages": [
 				{


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PRs matches the json objects based on a regex repalcement.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
