### PR TITLE
Pin berry constrain to 4 

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -146,7 +146,7 @@ api = "0.7"
     patches = 2
 
   [[metadata.dependency-constraints]]
-    constraint = ">=2"
+    constraint = "4.*"
     id = "berry"
     patches = 2
 

--- a/dependency/Makefile
+++ b/dependency/Makefile
@@ -2,6 +2,6 @@
 
 retrieve:
 	@cd retrieval; \
-	go run main.go \
+	go run . \
 		--buildpack-toml-path "${buildpackTomlPath}" \
 		--output "${output}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Sticking berry constrain to be 4 and not >= 2, as a major upgrade might happen and the semver might be patch. Also this allows us to have more than one major berry dependencies.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
